### PR TITLE
Correct Sass test failure

### DIFF
--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -40,7 +40,7 @@
 				}
 
 				.o-lazy-load-placeholder--3x2:after {
-					padding-bottom: 66.66667%;
+					padding-bottom: 66.6666666667%;
 				}
 
 				.o-lazy-load-placeholder--4x3:after {


### PR DESCRIPTION
Tests began to fail as we use dart sass for True Sass tests now in
origami-build-tools v10. We assumed updating to use dart sass for
True tests was not breaking as we already test components compile
with dart sass but we didn't think about the small changes in
output that would impact test assertions.