### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import LazyLoad from './../../main.js';
+import LazyLoad from './../../main.js.js';
 
 document.addEventListener('DOMContentLoaded', function () {
 	const doc = document.documentElement;

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import LazyLoad from './../../main.js.js';
+import LazyLoad from './../../main.js';
 
 document.addEventListener('DOMContentLoaded', function () {
 	const doc = document.documentElement;

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import LazyLoad from './src/js/o-lazy-load';
+import LazyLoad from './src/js/o-lazy-load.js';
 
 const constructAll = function () {
 	LazyLoad.init();

--- a/test/o-lazy-load.test.js
+++ b/test/o-lazy-load.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
-import waitUntil from './helpers/wait-until';
-import Subject from './../main';
+import * as fixtures from './helpers/fixtures.js';
+import waitUntil from './helpers/wait-until.js';
+import Subject from './../main.js';
 
 describe('o-lazy-load', () => {
 	let sandbox;


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing